### PR TITLE
Use updated way to set output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
       run: |
         git add .
         git commit -m "${{ inputs.message }}" || IS_CHANGED=0
-        echo "::set-output name=changed::${IS_CHANGED:-1}"
+        echo "changed=${IS_CHANGED:-1}" >> $GITHUB_OUTPUT
     - name: push
       shell: bash
       run: git push


### PR DESCRIPTION
Mitigate the warning "The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/"